### PR TITLE
Makefile: ContikiNG root path correction

### DIFF
--- a/simplelink-cc1310-oad/golden-image/Makefile
+++ b/simplelink-cc1310-oad/golden-image/Makefile
@@ -1,7 +1,7 @@
 CONTIKI_PROJECT = golden-image
 all: $(CONTIKI_PROJECT)
 
-CONTIKI = ../../..
+CONTIKI = ../../../..
 
 -include $(CONTIKI)/Makefile.identify-target
 


### PR DESCRIPTION
As this example is intended to build when cloned to the examples folder, when this repo is cloned to the examples folder the root directory is one more step above the specified path.